### PR TITLE
Prevent Slack flooding

### DIFF
--- a/src/DI/SlackLoggerExtension.php
+++ b/src/DI/SlackLoggerExtension.php
@@ -16,41 +16,45 @@ use Tracy\Debugger;
 
 class SlackLoggerExtension extends CompilerExtension
 {
-	private $defaults = [
-		'enabled' => FALSE,
-		'logUrl' => NULL,
-		'channel' => NULL,
-		'username' => NULL,
-		'icon' => NULL,
-		'pretext' => NULL,
-	];
+    private $defaults = [
+        'enabled' => FALSE,
+        'logUrl' => NULL,
+        'channel' => NULL,
+        'username' => NULL,
+        'icon' => NULL,
+        'pretext' => NULL,
+    ];
 
 
-	public function afterCompile(ClassType $class)
-	{
-		$config = $this->getConfig($this->defaults);
+    public function afterCompile(ClassType $class)
+    {
+        $config = $this->getConfig($this->defaults);
 
-		Validators::assertField($config, 'enabled', 'boolean');
+        Validators::assertField($config, 'enabled', 'boolean');
 
-		if ($config['enabled']) {
-			Validators::assertField($config, 'slackUrl', 'string');
-			Validators::assertField($config, 'logUrl', 'string|null');
-			Validators::assertField($config, 'channel', 'string|null');
-			Validators::assertField($config, 'username', 'string|null');
-			Validators::assertField($config, 'icon', 'string|null');
-			Validators::assertField($config, 'pretext', 'string|null');
+        if ($config['enabled']) {
+            Validators::assertField($config, 'slackUrl', 'string');
+            Validators::assertField($config, 'logUrl', 'string|null');
+            Validators::assertField($config, 'channel', 'string|null');
+            Validators::assertField($config, 'username', 'string|null');
+            Validators::assertField($config, 'icon', 'string|null');
+            Validators::assertField($config, 'pretext', 'string|null');
+            Validators::assertField($config, 'file', 'string|null');
+            Validators::assertField($config, 'interval', 'int|null');
 
-			$init = $class->getMethod('initialize');
-			$init->addBody('?::setLogger(new ?(?, ?, ?, ?, ?, ?));', [
-				new PhpLiteral(Debugger::class),
-				new PhpLiteral(SlackLogger::class),
-				$config['slackUrl'],
-				$config['logUrl'],
-				$config['channel'],
-				$config['username'],
-				$config['icon'],
-				$config['pretext'],
-			]);
-		}
-	}
+            $init = $class->getMethod('initialize');
+            $init->addBody('?::setLogger(new ?(?, ?, ?, ?, ?, ?, ?, ?));', [
+                new PhpLiteral(Debugger::class),
+                new PhpLiteral(SlackLogger::class),
+                $config['slackUrl'],
+                $config['logUrl'],
+                $config['channel'],
+                $config['username'],
+                $config['icon'],
+                $config['pretext'],
+                $config['file'],
+                $config['interval'],
+            ]);
+        }
+    }
 }

--- a/src/DI/SlackLoggerExtension.php
+++ b/src/DI/SlackLoggerExtension.php
@@ -3,6 +3,7 @@
  * @author Tomáš Blatný
  * @author Ondřej Bouda <bouda@edookit.com>
  */
+
 namespace OndrejBouda\NetteSlackLogger\DI;
 
 use OndrejBouda\NetteSlackLogger\SlackLogger;
@@ -17,12 +18,15 @@ use Tracy\Debugger;
 class SlackLoggerExtension extends CompilerExtension
 {
     private $defaults = [
-        'enabled' => FALSE,
-        'logUrl' => NULL,
-        'channel' => NULL,
-        'username' => NULL,
-        'icon' => NULL,
-        'pretext' => NULL,
+        'enabled' => false,
+        'logUrl' => null,
+        'channel' => null,
+        'username' => null,
+        'icon' => null,
+        'pretext' => null,
+        'interval' => null,
+        'file' => null,
+        'showIntervalWarning' => false,
     ];
 
 
@@ -40,10 +44,11 @@ class SlackLoggerExtension extends CompilerExtension
             Validators::assertField($config, 'icon', 'string|null');
             Validators::assertField($config, 'pretext', 'string|null');
             Validators::assertField($config, 'file', 'string|null');
-            Validators::assertField($config, 'interval', 'int|null');
+            Validators::assertField($config, 'interval', 'int|string|null');
+            Validators::assertField($config, 'showIntervalWarning', 'boolean|null');
 
             $init = $class->getMethod('initialize');
-            $init->addBody('?::setLogger(new ?(?, ?, ?, ?, ?, ?, ?, ?));', [
+            $init->addBody('?::setLogger(new ?(?, ?, ?, ?, ?, ?, ?, ?, ?));', [
                 new PhpLiteral(Debugger::class),
                 new PhpLiteral(SlackLogger::class),
                 $config['slackUrl'],
@@ -54,6 +59,7 @@ class SlackLoggerExtension extends CompilerExtension
                 $config['pretext'],
                 $config['file'],
                 $config['interval'],
+                $config['showIntervalWarning'],
             ]);
         }
     }

--- a/src/SlackLogger.php
+++ b/src/SlackLogger.php
@@ -14,6 +14,9 @@ use Tracy\Logger;
 
 class SlackLogger extends Logger
 {
+    //Default maximum length of Slack message is 5000 characters. Note that ~150 characters should be reserved for interval warning (see SlackLogger::$showIntervalWarning)
+    const MAX_MESSAGE_LENGTH = 4850;
+
     /** @var string */
     private $slackUrl;
     /** @var string */
@@ -26,15 +29,17 @@ class SlackLogger extends Logger
     private $icon;
     /** @var string */
     private $pretext;
-    /** @var int|string The minimum interval between two events. */
-    private $interval = '1 day';
+    /** @var int|string|null The minimum interval between two events. Accepts either number of seconds or date/time string for strtotime(). Attribute $file has to be set as well, otherwise $interval won't be acknowledged. */
+    private $interval;
     /** @var string|null File where the filter persists the state. */
     private $file;
     /** @var bool Indicates whether problems with the file write-ability was already logged (prevents recursion). */
     private $loggedUnwriteableFile = false;
+    /** @var bool Whether information about no more slack notifications for <interval> seconds shall be sent with error message */
+    private $showIntervalWarning = false;
 
 
-    public function __construct($slackUrl, $logUrl, $channel = null, $username = null, $icon = null, $pretext = null, $file = null, $interval = null)
+    public function __construct($slackUrl, $logUrl, $channel = null, $username = null, $icon = null, $pretext = null, $file = null, $interval = null, $showIntervalWarning = true)
     {
         parent::__construct(Debugger::$logDirectory, Debugger::$email, Debugger::getBlueScreen());
         $this->slackUrl = $slackUrl;
@@ -45,6 +50,7 @@ class SlackLogger extends Logger
         $this->pretext = $pretext;
         $this->file = $file;
         $this->interval = $interval;
+        $this->showIntervalWarning = $showIntervalWarning;
     }
 
 
@@ -53,36 +59,63 @@ class SlackLogger extends Logger
      */
     public function log($value, $priority = self::INFO)
     {
+        $notify = $this->isAllowedByInterval();
+
         $logFile = parent::log($value, $priority);
 
-        $message = ucfirst($priority) . ': ';
-        if ($value instanceof Exception || $value instanceof \Throwable) { // NOTE: backwards compatibility with PHP 5
-            $message .= $value->getMessage();
-        } elseif (is_array($value)) {
-            $message .= reset($value);
-        } else {
-            $message .= (string)$value;
+        if ($notify) {
+
+            $message = ucfirst($priority) . ': ';
+            if ($value instanceof Exception || $value instanceof \Throwable) { // NOTE: backwards compatibility with PHP 5
+                $message .= $value->getMessage();
+            } elseif (is_array($value)) {
+                $message .= reset($value);
+            } else {
+                $message .= (string)$value;
+            }
+
+            if ($logFile && $this->logUrl) {
+                $message .= ' (<' . str_replace('__FILE__', basename($logFile), $this->logUrl) . '|Open log file>)';
+            }
+
+            $truncated = mb_strlen($message) - self::MAX_MESSAGE_LENGTH;
+            $message = mb_substr($message, 0, self::MAX_MESSAGE_LENGTH);
+
+            if ($truncated > 0) {
+                $message .= '...' . PHP_EOL . '(' . $truncated . ')';
+            }
+
+            $interval = $this->getInterval();
+
+            if (isset($interval)) {
+                //log time of this notification
+                $this->mark();
+                if ($this->showIntervalWarning) {
+                    $message .= PHP_EOL . '*NOTE: No further Slack notifications will be sent for another ' . strtotime($interval) . ' seconds*';
+                }
+            }
+
+            //if interval after last update has passed, flush error message to Slack
+            $this->sendSlackMessage($message, $priority);
         }
+        return $logFile;
+    }
 
-        if ($logFile && $this->logUrl) {
-            $message .= ' (<' . str_replace('__FILE__', basename($logFile), $this->logUrl) . '|Open log file>)';
-        }
+    /**
+     * Marks the passed event and updates the stateful information.
+     *
+     * @return bool True whether mark was successful; false otherwise.
+     */
+    private function mark(): bool
+    {
+        $hasMarked = (bool)@file_put_contents($this->getFile(), static::class . PHP_EOL . date("r"));
 
-        $notify = $this->isAllowedByInterval();
-        //add logged message to buffer
-        $logSuccessful = (bool) @file_put_contents($this->getFile(), "\n" . date("r") . "\n" . $message, FILE_APPEND);
-
-        if (!$logSuccessful && !$this->loggedUnwriteableFile) {
+        if (!$hasMarked && !$this->loggedUnwriteableFile) {
             $this->loggedUnwriteableFile = true;
             trigger_error("Unable to write to file '{$this->getFile()}'. Filter will deny the incoming events.", E_USER_WARNING);
         }
 
-        if ($notify) {
-            //if interval after last update has passed, flush all messages in queue to Slack
-            $this->sendSlackMessage(@file_get_contents($this->getFile()), $priority);
-            @file_put_contents($this->getFile(), null);
-        }
-        return $logFile;
+        return $hasMarked;
     }
 
     private function isAllowedByInterval(): bool
@@ -90,8 +123,13 @@ class SlackLogger extends Logger
         $now = time();
 
         $interval = $this->getInterval();
-        if (!isset($interval)) {
-            return true;
+        $file = $this->getFile();
+        if (!isset($interval) || !isset($file)) {
+            if (!isset($interval)) {
+                return true;
+            } else {
+                throw new \InvalidArgumentException('Interval for SlackLogger is set, but no file for storing time of last notification is specified.');
+            }
         }
         if (!is_numeric($interval)) {
             $interval = strtotime($interval) - $now;
@@ -100,7 +138,7 @@ class SlackLogger extends Logger
         $lastEventTime = @filemtime($this->getFile());
         $nextPossibleEventTime = $lastEventTime + $interval;
 
-        return $now >= $nextPossibleEventTime;
+        return ($now >= $nextPossibleEventTime);
     }
 
     /**

--- a/src/SlackLogger.php
+++ b/src/SlackLogger.php
@@ -3,6 +3,7 @@
  * @author Tomáš Blatný
  * @author Ondřej Bouda <bouda@edookit.com>
  */
+
 namespace OndrejBouda\NetteSlackLogger;
 
 use Exception;
@@ -13,113 +14,171 @@ use Tracy\Logger;
 
 class SlackLogger extends Logger
 {
-	/** @var string */
-	private $slackUrl;
-	/** @var string */
-	private $logUrl;
-	/** @var string */
-	private $channel;
-	/** @var string */
-	private $username;
-	/** @var string */
-	private $icon;
-	/** @var string */
-	private $pretext;
+    /** @var string */
+    private $slackUrl;
+    /** @var string */
+    private $logUrl;
+    /** @var string */
+    private $channel;
+    /** @var string */
+    private $username;
+    /** @var string */
+    private $icon;
+    /** @var string */
+    private $pretext;
+    /** @var int|string The minimum interval between two events. */
+    private $interval = '1 day';
+    /** @var string|null File where the filter persists the state. */
+    private $file;
+    /** @var bool Indicates whether problems with the file write-ability was already logged (prevents recursion). */
+    private $loggedUnwriteableFile = false;
 
 
-	public function __construct($slackUrl, $logUrl, $channel = NULL, $username = NULL, $icon = NULL, $pretext = NULL)
-	{
-		parent::__construct(Debugger::$logDirectory, Debugger::$email, Debugger::getBlueScreen());
-		$this->slackUrl = $slackUrl;
-		$this->logUrl = $logUrl;
-		$this->channel = $channel;
-		$this->username = $username;
-		$this->icon = $icon;
-		$this->pretext = $pretext;
-	}
+    public function __construct($slackUrl, $logUrl, $channel = null, $username = null, $icon = null, $pretext = null, $file = null, $interval = null)
+    {
+        parent::__construct(Debugger::$logDirectory, Debugger::$email, Debugger::getBlueScreen());
+        $this->slackUrl = $slackUrl;
+        $this->logUrl = $logUrl;
+        $this->channel = $channel;
+        $this->username = $username;
+        $this->icon = $icon;
+        $this->pretext = $pretext;
+        $this->file = $file;
+        $this->interval = $interval;
+    }
 
 
-	/**
-	 * @inheritdoc
-	 */
-	public function log($value, $priority = self::INFO)
-	{
-		$logFile = parent::log($value, $priority);
+    /**
+     * @inheritdoc
+     */
+    public function log($value, $priority = self::INFO)
+    {
+        $logFile = parent::log($value, $priority);
 
-		$message = ucfirst($priority) . ': ';
-		if ($value instanceof Exception || $value instanceof \Throwable) { // NOTE: backwards compatibility with PHP 5
-			$message .= $value->getMessage();
-		} elseif (is_array($value)) {
-			$message .= reset($value);
-		} else {
-			$message .= (string) $value;
-		}
+        $message = ucfirst($priority) . ': ';
+        if ($value instanceof Exception || $value instanceof \Throwable) { // NOTE: backwards compatibility with PHP 5
+            $message .= $value->getMessage();
+        } elseif (is_array($value)) {
+            $message .= reset($value);
+        } else {
+            $message .= (string)$value;
+        }
 
-		if ($logFile && $this->logUrl) {
-			$message .= ' (<' . str_replace('__FILE__', basename($logFile), $this->logUrl) . '|Open log file>)';
-		}
+        if ($logFile && $this->logUrl) {
+            $message .= ' (<' . str_replace('__FILE__', basename($logFile), $this->logUrl) . '|Open log file>)';
+        }
 
-		$this->sendSlackMessage($message, $priority);
-		return $logFile;
-	}
+        $notify = $this->isAllowedByInterval();
+        //add logged message to buffer
+        $logSuccessful = (bool) @file_put_contents($this->getFile(), "\n" . date("r") . "\n" . $message, FILE_APPEND);
 
+        if (!$logSuccessful && !$this->loggedUnwriteableFile) {
+            $this->loggedUnwriteableFile = true;
+            trigger_error("Unable to write to file '{$this->getFile()}'. Filter will deny the incoming events.", E_USER_WARNING);
+        }
 
-	/**
-	 * @param string $message
-	 * @param string $priority one of {@link ILogger} priority constants
-	 */
-	private function sendSlackMessage($message, $priority)
-	{
-		$payload = array_filter([
-			'channel' => $this->channel,
-			'username' => $this->username,
-			'icon_emoji' => $this->icon,
-			'attachments' => [
-				array_filter([
-					'text' => $message,
-					'color' => self::getColor($priority),
-					'pretext' => $this->pretext,
-				]),
-			],
-		]);
+        if ($notify) {
+            //if interval after last update has passed, flush all messages in queue to Slack
+            $this->sendSlackMessage(@file_get_contents($this->getFile()), $priority);
+            @file_put_contents($this->getFile(), null);
+        }
+        return $logFile;
+    }
 
-		self::slackPost($this->slackUrl, ['payload' => json_encode($payload)]);
-	}
+    private function isAllowedByInterval(): bool
+    {
+        $now = time();
 
-	private static function getColor($priority)
-	{
-		switch ($priority) {
-			case ILogger::DEBUG:
-			case ILogger::INFO:
-				return '#444444';
+        $interval = $this->getInterval();
+        if (!isset($interval)) {
+            return true;
+        }
+        if (!is_numeric($interval)) {
+            $interval = strtotime($interval) - $now;
+        }
 
-			case ILogger::WARNING:
-				return 'warning';
+        $lastEventTime = @filemtime($this->getFile());
+        $nextPossibleEventTime = $lastEventTime + $interval;
 
-			case ILogger::ERROR:
-			case ILogger::EXCEPTION:
-			case ILogger::CRITICAL:
-				return 'danger';
+        return $now >= $nextPossibleEventTime;
+    }
 
-			default:
-				return null;
-		}
-	}
+    /**
+     * @return null|string
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
 
-	private static function slackPost($url, array $postContent)
-	{
-		$ctxOptions = [
-			'http' => [
-				'method' => 'POST',
-				'header' => 'Content-type: application/x-www-form-urlencoded',
-				'content' => http_build_query($postContent),
-			],
-		];
-		$ctx = stream_context_create($ctxOptions);
-		$resultStr = @file_get_contents($url, NULL, $ctx);
+    /**
+     * @return int|string
+     */
+    public function getInterval()
+    {
+        return $this->interval;
+    }
 
-		if ($resultStr != 'ok') {
-			throw new \RuntimeException('Error sending request to the Slack API: ' . $http_response_header[0]);
-		}
-	}
+    /**
+     * @param string $message
+     * @param string $priority one of {@link ILogger} priority constants
+     */
+    private function sendSlackMessage($message, $priority)
+    {
+        $payload = array_filter(
+            [
+                'channel' => $this->channel,
+                'username' => $this->username,
+                'icon_emoji' => $this->icon,
+                'attachments' => [
+                    array_filter(
+                        [
+                            'text' => $message,
+                            'color' => self::getColor($priority),
+                            'pretext' => $this->pretext,
+                        ]
+                    ),
+                ],
+            ]
+        );
+
+        self::slackPost($this->slackUrl, ['payload' => json_encode($payload)]);
+    }
+
+    private static function getColor($priority)
+    {
+        switch ($priority) {
+            case ILogger::DEBUG:
+            case ILogger::INFO:
+                return '#444444';
+
+            case ILogger::WARNING:
+                return 'warning';
+
+            case ILogger::ERROR:
+            case ILogger::EXCEPTION:
+            case ILogger::CRITICAL:
+                return 'danger';
+
+            default:
+                return null;
+        }
+    }
+
+    private static function slackPost($url, array $postContent)
+    {
+        $ctxOptions = [
+            'http' => [
+                'method' => 'POST',
+                'header' => 'Content-type: application/x-www-form-urlencoded',
+                'content' => http_build_query($postContent),
+            ],
+        ];
+        $ctx = stream_context_create($ctxOptions);
+        $resultStr = @file_get_contents($url, null, $ctx);
+
+        if ($resultStr != 'ok') {
+            throw new \RuntimeException('Error sending request to the Slack API: ' . $http_response_header[0]);
+        }
+    }
 }


### PR DESCRIPTION
Allow using min interval between two logged events to prevent flooding Slack with similar messages