### PR TITLE
fix marking the last message priority

### DIFF
--- a/src/SlackLogger.php
+++ b/src/SlackLogger.php
@@ -89,7 +89,7 @@ class SlackLogger extends Logger
 
             if ($interval !== null) {
                 //log time of this notification
-                $this->mark();
+                $this->mark($priority);
                 if ($this->showIntervalWarning) {
                     $secs = (is_numeric($interval) ? $interval : (strtotime($interval) ?: '?'));
                     $message .= PHP_EOL . '*NOTE: No further Slack notifications will be sent for another ' . $secs . ' seconds*';


### PR DESCRIPTION
The `mark` function call did not use the `priority` parameter, so the interval checking did not work for logs other than those of `INFO` priority (`mark` function default value)